### PR TITLE
Migrate screenshot to Gtk3

### DIFF
--- a/epoptes-client/lock-screen
+++ b/epoptes-client/lock-screen
@@ -31,7 +31,8 @@ import gobject
 import sys
 import time
 
-class lockscreen:
+
+class LockScreen:
     def lock(self, msg="The screen is locked by a system administrator."):
         backlock = gtk.Window(gtk.WINDOW_POPUP)
         backlock.resize(1, 1)
@@ -67,7 +68,6 @@ class lockscreen:
         # To automatically unlock the screen after 7 seconds, uncomment this:
         #gobject.timeout_add(7000, self.unlock)
 
-
     def fade(self, firsttime=False):
         if firsttime:
             self.fadesecs = 3.0
@@ -88,14 +88,13 @@ class lockscreen:
 
         return False
 
-
     def unlock(self):
         gdk.keyboard_ungrab(0L)
         exit()
 
 
 if len(sys.argv) <= 1:
-    lockscreen().lock()
+    LockScreen().lock()
 else:
-    lockscreen().lock(sys.argv[1])
+    LockScreen().lock(sys.argv[1])
 gtk.main()

--- a/epoptes-client/lock-screen
+++ b/epoptes-client/lock-screen
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ###########################################################################
@@ -24,36 +24,40 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ###########################################################################
 
-import gtk
-import gtk.gdk as gdk
-import pango
-import gobject
+import gi
 import sys
 import time
+gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gdk
+from gi.repository import GdkPixbuf
+from gi.repository import GObject
+from gi.repository import Gtk
+from gi.repository import Pango
 
 
 class LockScreen:
     def lock(self, msg="The screen is locked by a system administrator."):
-        backlock = gtk.Window(gtk.WINDOW_POPUP)
+        backlock = Gtk.Window(Gtk.WindowType.POPUP)
         backlock.resize(1, 1)
-        backlock.modify_bg(gtk.STATE_NORMAL, gdk.Color("#000000"))
-        frontview = gtk.Window()
-        frontview.modify_bg(gtk.STATE_NORMAL, gdk.Color("#000000"))
+        backlock.modify_bg(Gtk.StateType.NORMAL, Gdk.Color(0, 0, 0))
+        frontview = Gtk.Window()
+        frontview.modify_bg(Gtk.StateType.NORMAL, Gdk.Color(0, 0, 0))
 
-        vbox = gtk.VBox(spacing=75)
+        vbox = Gtk.VBox(spacing=75)
 
-        imagepb = gtk.gdk.pixbuf_new_from_file_at_size('lock.svg', 250, 250)
-        image = gtk.Image()
+        imagepb = GdkPixbuf.Pixbuf.new_from_file_at_size('lock.svg', 250, 250)
+        image = Gtk.Image()
         image.set_from_pixbuf(imagepb)
-        vbox.pack_start(image, True)
+        vbox.pack_start(image, True, True, 0)
 
         # Italic fonts are truncated in the sides, so add a space
-        self.label = gtk.Label(" " + msg + " ")
-        self.label.modify_font(pango.FontDescription('FreeSans italic 18'))
+        self.label = Gtk.Label(label=" " + msg + " ")
+        self.label.modify_font(Pango.FontDescription('FreeSans italic 18'))
         self.fade(True)
-        vbox.pack_start(self.label, True)
+        vbox.pack_start(self.label, True, True, 0)
 
-        align = gtk.Alignment(0.5, 0.5, 0, 0)
+        align = Gtk.Alignment.new(0.5, 0.5, 0, 0)
         align.add(vbox)
         frontview.add(align)
 
@@ -62,34 +66,33 @@ class LockScreen:
 
         frontview.set_keep_above(True)
         frontview.fullscreen()
-        gdk.beep()
-        gdk.keyboard_grab(backlock.window, False, 0L)
+        Gdk.beep()
+        Gdk.keyboard_grab(backlock.get_window(), False, 0)
 
         # To automatically unlock the screen after 7 seconds, uncomment this:
-        #gobject.timeout_add(7000, self.unlock)
+        #GObject.timeout_add(7000, self.unlock)
 
     def fade(self, firsttime=False):
         if firsttime:
             self.fadesecs = 3.0
             self.fadestart = time.time()
             # For debugging:
-            #print self.fadestart, self.fadesecs
+            #print(self.fadestart, self.fadesecs)
 
         percentage = (time.time() - self.fadestart) / self.fadesecs
-        i = min(round(255 * percentage), 255)
-        c = "#%02x%02x%02x" % (i, i, i)
+        i = min(round(Gdk.Color.MAX_VALUE * percentage), Gdk.Color.MAX_VALUE)
         # For debugging:
-        #print time.time(), '-', 100 * percentage, "completed, rendering color ", c
-        self.label.modify_fg(gtk.STATE_NORMAL, gdk.Color(c))
+        #print(time.time(), '-', 100 * percentage, "completed, rendering color ", i)
+        self.label.modify_fg(Gtk.StateType.NORMAL, Gdk.Color(i, i, i))
         # Put a sleep() here if you want to test for slow thin clients:
         #time.sleep(0.6)
-        if i < 255:
-            gobject.timeout_add(60, self.fade)
+        if i < Gdk.Color.MAX_VALUE:
+            GObject.timeout_add(60, self.fade)
 
         return False
 
     def unlock(self):
-        gdk.keyboard_ungrab(0L)
+        Gdk.keyboard_ungrab(0)
         exit()
 
 
@@ -97,4 +100,4 @@ if len(sys.argv) <= 1:
     LockScreen().lock()
 else:
     LockScreen().lock(sys.argv[1])
-gtk.main()
+Gtk.main()

--- a/epoptes-client/lock-screen
+++ b/epoptes-client/lock-screen
@@ -43,17 +43,21 @@ class LockScreen:
         backlock.modify_bg(Gtk.StateType.NORMAL, Gdk.Color(0, 0, 0))
         frontview = Gtk.Window()
         frontview.modify_bg(Gtk.StateType.NORMAL, Gdk.Color(0, 0, 0))
+        screen = Gdk.Screen.get_default()
+        swidth = screen.get_width()
+        sheight = screen.get_height()
+        smin = min(swidth, sheight)
+        frontview.resize(swidth, sheight)
 
         vbox = Gtk.VBox(spacing=75)
 
-        imagepb = GdkPixbuf.Pixbuf.new_from_file_at_size('lock.svg', 250, 250)
+        imagepb = GdkPixbuf.Pixbuf.new_from_file_at_size('lock.svg', smin/3, smin/3)
         image = Gtk.Image()
         image.set_from_pixbuf(imagepb)
         vbox.pack_start(image, True, True, 0)
 
-        # Italic fonts are truncated in the sides, so add a space
-        self.label = Gtk.Label(label=" " + msg + " ")
-        self.label.modify_font(Pango.FontDescription('FreeSans italic 18'))
+        self.label = Gtk.Label()
+        self.label.set_markup('<span size="' + str(10*swidth) + '"> ' + msg + ' </span>')
         self.fade(True)
         vbox.pack_start(self.label, True, True, 0)
 

--- a/epoptes-client/lock-screen
+++ b/epoptes-client/lock-screen
@@ -5,6 +5,7 @@
 # Lock the screen.
 #
 # Copyright (C) 2010 Fotis Tsamis <ftsamis@gmail.com>
+# 2018, Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +14,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -45,7 +46,7 @@ class lockscreen:
         image.set_from_pixbuf(imagepb)
         vbox.pack_start(image, True)
 
-        # Italic fonts are trancated in the sides, so add a space
+        # Italic fonts are truncated in the sides, so add a space
         self.label = gtk.Label(" " + msg + " ")
         self.label.modify_font(pango.FontDescription('FreeSans italic 18'))
         self.fade(True)

--- a/epoptes-client/screenshot
+++ b/epoptes-client/screenshot
@@ -1,10 +1,11 @@
-#!/usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ###########################################################################
 # Screenshot.
 #
 # Copyright (C) 2010 Fotis Tsamis <ftsamis@gmail.com>
+# 2018, Alkis Georgopoulos <alkisg@gmail.com>
 # Many thanks to Uli Schlachter <psychon@znc.in> for helping with the cairo stuff
 #
 # This program is free software: you can redistribute it and/or modify
@@ -14,7 +15,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -24,34 +25,42 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ############################################################################
 
-import gtk.gdk as gdk
-from sys import stdout, stderr, argv
+import cairo
+import gi
+import sys
+gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gdk
+from gi.repository import Gtk
 
-if len(argv) == 3:
-    width, height = int(argv[1]), int(argv[2])
+
+if len(sys.argv) == 3:
+    width, height = int(sys.argv[1]), int(sys.argv[2])
 else:
+    sys.stderr.write("Usage: screenshot width height\n")
     exit(1)
 
-root = gdk.get_default_root_window()
+root = Gdk.get_default_root_window()
 if root is None:
     exit(1)
-r_width, r_height = root.get_size()
+geometry = root.get_geometry()
 
-pmap = gdk.Pixmap(root, width, height)
-cr = pmap.cairo_create()
-cr.scale(float(width)/r_width, float(height)/r_height)
-cr.set_source_pixmap(root, 0, 0)
+surface = cairo.ImageSurface(cairo.FORMAT_RGB24, width, height)
+cr = cairo.Context(surface)
+cr.scale(float(width)/geometry.width, float(height)/geometry.height)
+Gdk.cairo_set_source_window(cr, root, 0, 0)
 cr.paint()
 
-pixbuf = gdk.Pixbuf(gdk.COLORSPACE_RGB, False, 8, width, height)
-pixbuf.get_from_drawable(pmap, root.get_colormap(), 0, 0, 0, 0, width, height)
-
-rowst = str(pixbuf.get_rowstride())
+pixbuf = Gdk.pixbuf_get_from_surface(surface, 0, 0, width, height)
+rowst = pixbuf.get_rowstride()
 pixels = pixbuf.get_pixels()
 
 try:
-    stdout.flush()
-    stdout.write('%s\n%ix%i\n%s' %(rowst, width, height, pixels))
-    stdout.flush()
+    sys.stdout.buffer.flush()
+    sys.stdout.buffer.write(bytearray("%s\n%ix%i\n" % (rowst, width, height), "ascii"))
+    sys.stdout.buffer.write(pixels)
+    # TODO: for some reason, the last padding isn't included, so do it manually
+    sys.stdout.buffer.write(b"\0"*(rowst - 3*width))
+    sys.stdout.buffer.flush()
 except:
-    stderr.write("Error while sending screenshot\n")
+    sys.stderr.write("Error while sending screenshot\n")


### PR DESCRIPTION
This pull request migrates screenshot to Python3/Gtk3.
It's using almost the same API as the Python2/Gtk2 version, so its performance should be similar, i.e. doing server-side image stretching.

In order to avoid text encoding conversion (which Python 3 defaults to, corrupting the pixmap), sys.stdout.buffer was used to write to stdout in binary mode. But for some reason, the padding of the last line isn't serialized, so I had to append it manually.