### PR TITLE
Migrate Epoptes to Gtk3

### DIFF
--- a/bin/epoptes
+++ b/bin/epoptes
@@ -4,7 +4,7 @@
 ###########################################################################
 # Launch the epoptes UI.
 #
-# Copyright (C) 2011 Alkis Georgopoulos <alkisg@gmail.com>
+# Copyright (C) 2011-2018 Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +13,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -23,10 +23,14 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ###########################################################################
 
+from __future__ import print_function
 import os
 import os.path
 import sys
-import gtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
 import epoptes
 
 # cd to the epoptes directory, so that all paths are relative
@@ -34,12 +38,12 @@ os.chdir('/usr/share/epoptes')
 
 if len(sys.argv) > 1:
     if sys.argv[1] in ('--version', '-version'):
-        print "Epoptes %s" % epoptes.__version__
+        print("Epoptes %s" % epoptes.__version__)
         sys.exit(0)
 
 # Do these potentially expensive imports now we know the environment is sane
-from twisted.internet import gtk2reactor
-gtk2reactor.install()
+from twisted.internet import gtk3reactor
+gtk3reactor.install()
 from twisted.internet import reactor
 from twisted.internet.protocol import ClientCreator
 from twisted.protocols import amp
@@ -55,10 +59,11 @@ path = os.path.expanduser('~/.config/epoptes/')
 if not os.path.isdir(path):
     os.makedirs(path)
 
+
 def connectionFailed(failure):
     msg = _("An error occurred while trying to connect to the epoptes service:")
     msg += ' <i>' + failure.value.message + '</i>\n\n'
-    print "Connection with epoptes failed:", failure.value.message
+    print("Connection with epoptes failed:", failure.value.message)
     # Permission denied error
     if failure.value.osError == 13:
         msg += _("User %s must be a member of group %s to run epoptes.") % \
@@ -66,12 +71,13 @@ def connectionFailed(failure):
     # No such file error
     elif failure.value.osError == 2:
         msg += _("Make sure the epoptes service is running.")
-    dlg = gtk.MessageDialog(type=gtk.MESSAGE_ERROR, buttons=gtk.BUTTONS_OK)
+    dlg = Gtk.MessageDialog(type=Gtk.MessageType.ERROR, buttons=Gtk.ButtonsType.OK)
     dlg.set_markup(msg)
     dlg.set_title(_('Service connection error'))
     dlg.run()
     dlg.destroy()
     reactor.stop()
+
 
 d = ClientCreator(reactor, epoptes.daemon.uiconnection.Daemon, epoptesGui).connectUNIX(config.system['DIR'] + "/epoptes.socket")
 d.addErrback(connectionFailed)

--- a/epoptes/common/config.py
+++ b/epoptes/common/config.py
@@ -4,7 +4,7 @@
 ###########################################################################
 # Configuration file parser and other default configuration variables.
 #
-# Copyright (C) 2011 Alkis Georgopoulos <alkisg@gmail.com>
+# Copyright (C) 2011-2018 Alkis Georgopoulos <alkisg@gmail.com>
 # Copyright (C) 2011 Fotis Tsamis <ftsamis@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -14,7 +14,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -227,5 +227,4 @@ history = read_plain_file(os.path.join(path, 'history'))
 
 # For debugging reasons, if ran from command line, dump the config
 if __name__ == '__main__':
-    print system
-
+    print(system)

--- a/epoptes/ui/about_dialog.py
+++ b/epoptes/ui/about_dialog.py
@@ -5,6 +5,7 @@
 # About dialog.
 #
 # Copyright (C) 2010 Fotis Tsamis <ftsamis@gmail.com>
+# 2018, Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,26 +24,22 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ###########################################################################
 
-import gtk
-import pygtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 
 from epoptes import __version__
 
+
 class About:
     def __init__(self):
-        self.wTree = gtk.Builder()
+        self.wTree = Gtk.Builder()
         self.wTree.add_from_file('about_dialog.ui')
         self.wTree.connect_signals(self)
-        self.get = self.wTree.get_object
-        
-        self.dialog = self.get('aboutdialog')
-        logo = gtk.gdk.pixbuf_new_from_file_at_size(
-            '../icons/hicolor/scalable/apps/epoptes.svg', 64, 64)
-        self.dialog.set_logo(logo)
+
+        self.dialog = self.wTree.get_object('aboutdialog')
         self.dialog.set_version(__version__)
-        self.dialog.set_translator_credits(_("translator-credits"))
-        self.dialog.set_artists(["Andrew Wedderburn (application icon)"])
-    
+
     def run(self):
         self.dialog.run()
         self.dialog.destroy()

--- a/epoptes/ui/about_dialog.py
+++ b/epoptes/ui/about_dialog.py
@@ -14,7 +14,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -32,12 +32,13 @@ from epoptes import __version__
 
 
 class About:
-    def __init__(self):
+    def __init__(self, parent):
         self.wTree = Gtk.Builder()
         self.wTree.add_from_file('about_dialog.ui')
         self.wTree.connect_signals(self)
 
         self.dialog = self.wTree.get_object('aboutdialog')
+        self.dialog.set_transient_for(parent)
         self.dialog.set_version(__version__)
 
     def run(self):

--- a/epoptes/ui/client_information.py
+++ b/epoptes/ui/client_information.py
@@ -5,6 +5,7 @@
 # Get client properties.
 #
 # Copyright (C) 2010 Fotis Tsamis <ftsamis@gmail.com>
+# 2018, Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +14,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -23,21 +24,25 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ###########################################################################
 
-import gtk
-import pygtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 
 from epoptes.common.constants import *
 
+
 class ClientInformation:
-    def __init__(self, selected, execute):
-        self.wTree = gtk.Builder()
+    def __init__(self, parent, selected, execute):
+        self.wTree = Gtk.Builder()
         self.wTree.add_from_file('client_information.ui')
         self.wTree.connect_signals(self)
         self.get = self.wTree.get_object
         self.selected = selected
         
         self.dlg = self.get('infodlg')
+        self.dlg.set_transient_for(parent)
         self.edit_button = self.get('edit_alias_button')
+        // TODO: reduce unnecessary lambdas
         set = lambda wdg, txt: self.get(wdg).set_text(txt.strip())
 
         for client in selected:
@@ -63,7 +68,7 @@ class ClientInformation:
                     user += ' (%s)' %realname
             set('client_online_user', user)
             self.dlg.set_title(_('Properties of %s') %inst.get_name())
-        
+
     def run(self):
         self.dlg.run()
         self.dlg.destroy()

--- a/epoptes/ui/graph.py
+++ b/epoptes/ui/graph.py
@@ -5,6 +5,7 @@
 # Graph generator.
 #
 # Copyright (C) 2016 Fotis Tsamis <ftsamis@gmail.com>
+# 2018, Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +14,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -23,14 +24,17 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ###########################################################################
 
-import gtk
-import cairo
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+import cairo  # TODO: put python-gi-cairo in debian dependencies
 from pycha.bar import HorizontalBarChart
 
-class Graph(gtk.DrawingArea):
+
+class Graph(Gtk.DrawingArea):
     def __init__(self):
-        gtk.DrawingArea.__init__(self)
-        self.connect("expose-event", self.expose)
+        Gtk.DrawingArea.__init__(self)
+        self.connect("draw", self.draw)
         self.connect("size-allocate", self.size_allocate)
         self._surface = None
         self._options = None
@@ -47,15 +51,7 @@ class Graph(gtk.DrawingArea):
         chart.addDataset(self._data)
         chart.render()
  
-    def expose(self, widget, event):
-        context = widget.window.cairo_create()
-        context.rectangle(event.area.x, event.area.y,
-                          event.area.width, event.area.height)
-        context.clip()
-        self.draw(context)
-        return False
- 
-    def draw(self, context):
+    def draw(self, widget, context):
         rect = self.get_allocation()
         self._surface = cairo.ImageSurface(cairo.FORMAT_ARGB32,
                                            rect.width, rect.height)
@@ -65,4 +61,3 @@ class Graph(gtk.DrawingArea):
  
     def size_allocate(self, widget, requisition):
         self.queue_draw()
-

--- a/epoptes/ui/gtk/about_dialog.ui
+++ b/epoptes/ui/gtk/about_dialog.ui
@@ -1,42 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkAboutDialog" id="aboutdialog">
     <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">normal</property>
-    <property name="skip_taskbar_hint">True</property>
+    <property name="type_hint">dialog</property>
     <property name="program_name">Epoptes</property>
-    <property name="copyright" translatable="yes">Copyright © 2011-2016 The Epoptes Team</property>
+    <property name="version">1.0</property>
+    <property name="copyright" translatable="yes">Copyright © 2011-2018 The Epoptes Team</property>
     <property name="comments" translatable="yes">A computer lab management and monitoring tool.</property>
     <property name="website">http://www.epoptes.org</property>
-    <property name="license" translatable="yes">Epoptes is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version. 
-
-Epoptes is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
-
-You should have received a copy of the GNU General Public License along with epoptes. If not, see &lt;http://www.gnu.org/licenses/&gt;.</property>
+    <property name="website_label">http://www.epoptes.org</property>
     <property name="authors">Alkis Georgopoulos &lt;alkisg@gmail.com&gt;
 Fotis Tsamis &lt;ftsamis@gmail.com&gt;</property>
-    <property name="wrap_license">True</property>
+    <property name="translator_credits" translatable="yes">translator-credits</property>
+    <property name="artists">Andrew Wedderburn (application icon)</property>
+    <property name="logo_icon_name">epoptes</property>
+    <property name="license_type">gpl-3-0</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
-        <property name="visible">True</property>
+      <object class="GtkBox">
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
-            <property name="visible">True</property>
+          <object class="GtkButtonBox">
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
         </child>
       </object>
     </child>

--- a/epoptes/ui/gtk/client_information.ui
+++ b/epoptes/ui/gtk/client_information.ui
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="edit_alias_dialog">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Edit alias</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox3">
+      <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area3">
+          <object class="GtkButtonBox" id="dialog-action_area3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -23,7 +27,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -38,7 +41,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -56,16 +58,15 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox2">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="spacing">14</property>
             <child>
               <object class="GtkImage" id="image2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="stock">gtk-edit</property>
-                <property name="icon-size">6</property>
+                <property name="icon_size">6</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -92,7 +93,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -102,13 +103,11 @@
             <property name="invisible_char">●</property>
             <property name="primary_icon_activatable">False</property>
             <property name="secondary_icon_activatable">False</property>
-            <property name="primary_icon_sensitive">True</property>
-            <property name="secondary_icon_sensitive">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -120,18 +119,24 @@
   </object>
   <object class="GtkDialog" id="infodlg">
     <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="border_width">12</property>
     <property name="icon_name">document-properties</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox2">
+      <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">2</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area2">
+          <object class="GtkButtonBox" id="dialog-action_area2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="orientation">vertical</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button5">
@@ -139,7 +144,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -157,269 +161,231 @@
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="propertiestable">
+          <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="border_width">10</property>
-            <property name="n_rows">9</property>
-            <property name="n_columns">2</property>
-            <property name="column_spacing">10</property>
-            <property name="row_spacing">10</property>
-            <child>
-              <object class="GtkLabel" id="label3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Graphics card:</property>
-              </object>
-              <packing>
-                <property name="top_attach">8</property>
-                <property name="bottom_attach">9</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="client_vga">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="selectable">True</property>
-                <property name="single_line_mode">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">8</property>
-                <property name="bottom_attach">9</property>
-                <property name="x_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">RAM:</property>
-              </object>
-              <packing>
-                <property name="top_attach">7</property>
-                <property name="bottom_attach">8</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="client_ram">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="selectable">True</property>
-                <property name="single_line_mode">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">7</property>
-                <property name="bottom_attach">8</property>
-                <property name="x_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Processor:</property>
-              </object>
-              <packing>
-                <property name="top_attach">6</property>
-                <property name="bottom_attach">7</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="client_cpu">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="selectable">True</property>
-                <property name="single_line_mode">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">6</property>
-                <property name="bottom_attach">7</property>
-                <property name="x_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label7">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">User:</property>
-              </object>
-              <packing>
-                <property name="top_attach">5</property>
-                <property name="bottom_attach">6</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="client_online_user">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">5</property>
-                <property name="bottom_attach">6</property>
-                <property name="x_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label10">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">IP address:</property>
-              </object>
-              <packing>
-                <property name="top_attach">4</property>
-                <property name="bottom_attach">5</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="client_ip">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">4</property>
-                <property name="bottom_attach">5</property>
-                <property name="x_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label6">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">MAC address:</property>
-              </object>
-              <packing>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="client_mac">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
-                <property name="x_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label4">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Client hostname:</property>
-              </object>
-              <packing>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="client_hostname">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-              </packing>
-            </child>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="column_spacing">12</property>
+            <property name="row_homogeneous">True</property>
             <child>
               <object class="GtkLabel" id="label5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
                 <property name="label" translatable="yes">Client type:</property>
-              </object>
-              <packing>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="client_type">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="selectable">True</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="label8">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
                 <property name="label" translatable="yes">Client alias:</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
               </packing>
             </child>
             <child>
-              <object class="GtkHBox" id="hbox1">
+              <object class="GtkLabel" id="label4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Client hostname:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label6">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">MAC address:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label10">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">IP address:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label7">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">User:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Processor:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">RAM:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Graphics card:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="client_type">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="client_hostname">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="client_mac">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="client_ip">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="client_online_user">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="client_cpu">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">True</property>
+                <property name="single_line_mode">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="client_ram">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">True</property>
+                <property name="single_line_mode">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="client_vga">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">True</property>
+                <property name="single_line_mode">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
                 <child>
                   <object class="GtkLabel" id="client_alias">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -432,7 +398,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
                     <signal name="clicked" handler="on_edit_alias_clicked" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="image1">
@@ -451,16 +416,14 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
                 <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
       </object>

--- a/epoptes/ui/gtk/client_information.ui
+++ b/epoptes/ui/gtk/client_information.ui
@@ -2,121 +2,6 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
-  <object class="GtkDialog" id="edit_alias_dialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Edit alias</property>
-    <property name="type_hint">normal</property>
-    <child>
-      <placeholder/>
-    </child>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox3">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">12</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area3">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="alias_edited">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="alias_edit_cancel">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkImage" id="image2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="stock">gtk-edit</property>
-                <property name="icon_size">6</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label9">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Set a new alias for the selected client</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="alias_entry">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="invisible_char">●</property>
-            <property name="primary_icon_activatable">False</property>
-            <property name="secondary_icon_activatable">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="1">alias_edited</action-widget>
-      <action-widget response="0">alias_edit_cancel</action-widget>
-    </action-widgets>
-  </object>
   <object class="GtkDialog" id="infodlg">
     <property name="can_focus">False</property>
     <property name="border_width">12</property>
@@ -430,6 +315,122 @@
     </child>
     <action-widgets>
       <action-widget response="0">button5</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkDialog" id="edit_alias_dialog">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Edit alias</property>
+    <property name="type_hint">normal</property>
+    <property name="transient_for">infodlg</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox3">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area3">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="alias_edited">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="alias_edit_cancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkImage" id="image2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="stock">gtk-edit</property>
+                <property name="icon_size">6</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label9">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Set a new alias for the selected client</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="alias_entry">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="invisible_char">●</property>
+            <property name="primary_icon_activatable">False</property>
+            <property name="secondary_icon_activatable">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="1">alias_edited</action-widget>
+      <action-widget response="0">alias_edit_cancel</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/epoptes/ui/gtk/epoptes.ui
+++ b/epoptes/ui/gtk/epoptes.ui
@@ -1,36 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
-  <!-- interface-local-resource-path /home/phantomas/code/epoptes/trunk/data/images -->
-  <object class="GtkMenu" id="broadcastmenu">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkImageMenuItem" id="broadcast_full">
-        <property name="label" translatable="yes">Broadcast screen (fullscreen)</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients, fullscreen</property>
-        <property name="use_action_appearance">False</property>
-        <property name="image">image43</property>
-        <property name="use_stock">False</property>
-        <signal name="activate" handler="broadcastScreen" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkImageMenuItem" id="broadcast_window">
-        <property name="label" translatable="yes">Broadcast screen (windowed)</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients, in a window</property>
-        <property name="use_action_appearance">False</property>
-        <property name="image">image42</property>
-        <property name="use_stock">False</property>
-        <signal name="activate" handler="broadcastScreenWindowed" swapped="no"/>
-      </object>
-    </child>
-  </object>
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="entrydialog">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -40,13 +11,17 @@
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">normal</property>
     <property name="skip_taskbar_hint">True</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox4">
+      <object class="GtkBox" id="dialog-vbox4">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area4">
+          <object class="GtkButtonBox" id="dialog-action_area4">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -56,7 +31,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -71,7 +45,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -96,8 +69,6 @@
             <property name="invisible_char">●</property>
             <property name="primary_icon_activatable">False</property>
             <property name="secondary_icon_activatable">False</property>
-            <property name="primary_icon_sensitive">True</property>
-            <property name="secondary_icon_sensitive">True</property>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -111,37 +82,6 @@
       <action-widget response="1">button1</action-widget>
       <action-widget response="0">button2</action-widget>
     </action-widgets>
-  </object>
-  <object class="GtkMessageDialog" id="executionwarning">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Confirm action</property>
-    <property name="modal">True</property>
-    <property name="type_hint">normal</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="transient_for">mainwindow</property>
-    <property name="message_type">warning</property>
-    <property name="buttons">yes-no</property>
-    <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox6">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area6">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-      </object>
-    </child>
   </object>
   <object class="GtkAdjustment" id="iconsSizeAdjustment">
     <property name="lower">50</property>
@@ -326,6 +266,32 @@
     <property name="can_focus">False</property>
     <property name="pixbuf">images/16/broadcast.png</property>
   </object>
+  <object class="GtkMenu" id="broadcastmenu">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkImageMenuItem" id="broadcast_full">
+        <property name="label" translatable="yes">Broadcast screen (fullscreen)</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients, fullscreen</property>
+        <property name="image">image43</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="broadcastScreen" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="broadcast_window">
+        <property name="label" translatable="yes">Broadcast screen (windowed)</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients, in a window</property>
+        <property name="image">image42</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="broadcastScreenWindowed" swapped="no"/>
+      </object>
+    </child>
+  </object>
   <object class="GtkImage" id="image47">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -391,11 +357,6 @@
     <property name="can_focus">False</property>
     <property name="pixbuf">images/16/broadcast-stop.png</property>
   </object>
-  <object class="GtkImage" id="image8">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">emblem-people</property>
-  </object>
   <object class="GtkWindow" id="mainwindow">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -405,9 +366,13 @@
     <property name="icon">../icons/hicolor/scalable/apps/epoptes.svg</property>
     <signal name="destroy" handler="on_mainwin_destroy" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkMenuBar" id="miClients">
             <property name="visible">True</property>
@@ -416,7 +381,6 @@
               <object class="GtkMenuItem" id="file">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">_File</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
@@ -428,7 +392,6 @@
                         <property name="label">gtk-quit</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_mainwin_destroy" swapped="no"/>
@@ -442,7 +405,6 @@
               <object class="GtkMenuItem" id="miClientView">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Labels</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu15">
@@ -452,7 +414,6 @@
                       <object class="GtkRadioMenuItem" id="miClientsViewHostUser">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Computer (user)</property>
                         <property name="use_underline">True</property>
                         <property name="active">True</property>
@@ -465,7 +426,6 @@
                       <object class="GtkRadioMenuItem" id="miClientsViewHost">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Computer</property>
                         <property name="use_underline">True</property>
                         <property name="draw_as_radio">True</property>
@@ -477,7 +437,6 @@
                       <object class="GtkRadioMenuItem" id="miClientsViewUserHost">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">User (computer)</property>
                         <property name="use_underline">True</property>
                         <property name="draw_as_radio">True</property>
@@ -489,7 +448,6 @@
                       <object class="GtkRadioMenuItem" id="miClientsViewUser">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">User</property>
                         <property name="use_underline">True</property>
                         <property name="draw_as_radio">True</property>
@@ -505,7 +463,6 @@
                       <object class="GtkCheckMenuItem" id="mcShowRealNames">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Show real names</property>
                         <property name="use_underline">True</property>
                         <signal name="toggled" handler="toggleRealNames" swapped="no"/>
@@ -519,7 +476,6 @@
               <object class="GtkMenuItem" id="clients">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">_Clients</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
@@ -530,7 +486,6 @@
                       <object class="GtkMenuItem" id="miSession">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Session</property>
                         <property name="use_underline">True</property>
                         <child type="submenu">
@@ -542,7 +497,6 @@
                                 <property name="label" translatable="yes">Boot</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image40</property>
                                 <property name="use_stock">False</property>
@@ -554,7 +508,6 @@
                                 <property name="label" translatable="yes">Log out</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image30</property>
                                 <property name="use_stock">False</property>
@@ -566,7 +519,6 @@
                                 <property name="label" translatable="yes">Reboot</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image41</property>
                                 <property name="use_stock">False</property>
@@ -578,7 +530,6 @@
                                 <property name="label" translatable="yes">Shutdown</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image31</property>
                                 <property name="use_stock">False</property>
@@ -593,7 +544,6 @@
                       <object class="GtkMenuItem" id="miTransmissions">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Broadcasts</property>
                         <property name="use_underline">True</property>
                         <child type="submenu">
@@ -605,7 +555,6 @@
                                 <property name="label" translatable="yes">Monitor user</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="image">image12</property>
                                 <property name="use_stock">False</property>
                                 <signal name="activate" handler="monitorUser" swapped="no"/>
@@ -617,7 +566,6 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">Take control of the selected user's computer</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image36</property>
                                 <property name="use_stock">False</property>
@@ -629,7 +577,6 @@
                                 <property name="label" translatable="yes">Broadcast video</property>
                                 <property name="sensitive">False</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image35</property>
                                 <property name="use_stock">False</property>
@@ -641,7 +588,6 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients, fullscreen</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image34</property>
                                 <property name="use_stock">False</property>
@@ -654,7 +600,6 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients, in a window</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image14</property>
                                 <property name="use_stock">False</property>
@@ -666,7 +611,6 @@
                                 <property name="label" translatable="yes">Broadcast user</property>
                                 <property name="sensitive">False</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image33</property>
                                 <property name="use_stock">False</property>
@@ -678,7 +622,6 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">Stops all active broadcasts</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image7</property>
                                 <property name="use_stock">False</property>
@@ -690,7 +633,6 @@
                                 <property name="label" translatable="yes">Open broadcasts window</property>
                                 <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">Open a windowed session to prevent broadcasting your whole screen</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="image">image38</property>
                                 <property name="use_stock">False</property>
                               </object>
@@ -703,7 +645,6 @@
                       <object class="GtkMenuItem" id="miExecuteMenu">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Execute</property>
                         <child type="submenu">
                           <object class="GtkMenu" id="menu5">
@@ -715,7 +656,6 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">Execute a command on the selected clients</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="use_stock">True</property>
                                 <signal name="activate" handler="execDialog" swapped="no"/>
@@ -727,7 +667,6 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">Send a message to the selected clients</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image56</property>
                                 <property name="use_stock">False</property>
@@ -738,7 +677,6 @@
                               <object class="GtkMenuItem" id="miOpenTerminal">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="label" translatable="yes">Open terminal</property>
                                 <child type="submenu">
                                   <object class="GtkMenu" id="menu12">
@@ -749,7 +687,6 @@
                                         <property name="label" translatable="yes">User, locally</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="image">image60</property>
                                         <property name="use_stock">False</property>
                                         <signal name="activate" handler="openUserTerminal" swapped="no"/>
@@ -760,7 +697,6 @@
                                         <property name="label" translatable="yes">Root, locally</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="image">image61</property>
                                         <property name="use_stock">False</property>
                                         <signal name="activate" handler="openRootTerminal" swapped="no"/>
@@ -771,7 +707,6 @@
                                         <property name="label" translatable="yes">Root, remotely</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="image">image62</property>
                                         <property name="use_stock">False</property>
                                         <signal name="activate" handler="remoteRootTerminal" swapped="no"/>
@@ -789,7 +724,6 @@
                       <object class="GtkMenuItem" id="miClientRestrictions">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Restrictions</property>
                         <property name="use_underline">True</property>
                         <child type="submenu">
@@ -801,7 +735,6 @@
                                 <property name="label" translatable="yes">Lock screen</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="image">image29</property>
                                 <property name="use_stock">False</property>
                                 <signal name="activate" handler="lockScreen" swapped="no"/>
@@ -812,7 +745,6 @@
                                 <property name="label" translatable="yes">Unlock screen</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="image">image37</property>
                                 <property name="use_stock">False</property>
                                 <signal name="activate" handler="unlockScreen" swapped="no"/>
@@ -828,7 +760,6 @@
                                 <property name="label" translatable="yes">Block Internet</property>
                                 <property name="sensitive">False</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image47</property>
                                 <property name="use_stock">False</property>
@@ -839,7 +770,6 @@
                                 <property name="label" translatable="yes">Unblock Internet</property>
                                 <property name="sensitive">False</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image48</property>
                                 <property name="use_stock">False</property>
@@ -856,7 +786,6 @@
                                 <property name="label" translatable="yes">Mute sound</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image50</property>
                                 <property name="use_stock">False</property>
@@ -868,7 +797,6 @@
                                 <property name="label" translatable="yes">Unmute sound</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="image">image49</property>
                                 <property name="use_stock">False</property>
@@ -878,7 +806,6 @@
                             <child>
                               <object class="GtkMenuItem" id="miUsersBackground">
                                 <property name="can_focus">False</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="label" translatable="yes">Background image</property>
                                 <property name="use_underline">True</property>
                                 <child type="submenu">
@@ -891,7 +818,6 @@
                                         <property name="visible">True</property>
                                         <property name="sensitive">False</property>
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="image">image26</property>
                                         <property name="use_stock">False</property>
@@ -903,7 +829,6 @@
                                         <property name="visible">True</property>
                                         <property name="sensitive">False</property>
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="image">image27</property>
                                         <property name="use_stock">False</property>
@@ -915,7 +840,6 @@
                                         <property name="visible">True</property>
                                         <property name="sensitive">False</property>
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="image">image28</property>
                                         <property name="use_stock">False</property>
@@ -940,7 +864,6 @@
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Add to group</property>
                         <property name="use_underline">True</property>
                         <child type="submenu">
@@ -949,14 +872,13 @@
                             <property name="can_focus">False</property>
                           </object>
                         </child>
-                      </object>  
+                      </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="miRemoveFromGroup">
                         <property name="label" translatable="yes">Remove from group</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="image">image13</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="on_remove_from_group_clicked" swapped="no"/>
@@ -972,7 +894,6 @@
                       <object class="GtkMenuItem" id="miBenchmark">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Network Benchmark</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="on_miBenchmark_activate" swapped="no"/>
@@ -983,7 +904,6 @@
                         <property name="label">gtk-info</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_tb_client_properties_clicked" swapped="no"/>
@@ -997,7 +917,6 @@
               <object class="GtkMenuItem" id="help">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">_Help</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
@@ -1009,7 +928,6 @@
                         <property name="label">gtk-home</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="openHelpLink" swapped="no"/>
@@ -1020,7 +938,6 @@
                         <property name="label" translatable="yes">Report a bug</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="image">image2</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="openBugsLink" swapped="no"/>
@@ -1031,7 +948,6 @@
                         <property name="label" translatable="yes">Ask a question</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="image">image3</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="openQuestionsLink" swapped="no"/>
@@ -1042,7 +958,6 @@
                         <property name="label" translatable="yes">Translate this application</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="image">image51</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="openTranslationsLink" swapped="no"/>
@@ -1053,7 +968,6 @@
                         <property name="label" translatable="yes">Live chat (IRC)</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="image">image52</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="openIRCLink" swapped="no"/>
@@ -1070,7 +984,6 @@
                         <property name="label" translatable="yes">Remote support</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="image">image39</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="on_mi_remote_assistance_activate" swapped="no"/>
@@ -1087,7 +1000,6 @@
                         <property name="label">gtk-about</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_mi_about_activate" swapped="no"/>
@@ -1114,7 +1026,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Boot selected clients (Wake On LAN)</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Boot</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image15</property>
@@ -1130,7 +1041,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Log out users connected on selected clients</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Log out</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image16</property>
@@ -1146,7 +1056,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Reboot the selected clients</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Reboot</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image17</property>
@@ -1162,7 +1071,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Shutdown the selected clients</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Shutdown</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image18</property>
@@ -1180,6 +1088,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -1187,7 +1096,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Take control of the selected user's computer</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Assist user</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image32</property>
@@ -1203,7 +1111,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Broadcast screen</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image19</property>
@@ -1217,7 +1124,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients, fullscreen</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Broadcast screen (fullscreen)</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="broadcastScreen" swapped="no"/>
@@ -1228,7 +1134,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Broadcast your screen to the selected clients, in a window</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">Broadcast screen (windowed)</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="broadcastScreenWindowed" swapped="no"/>
@@ -1239,6 +1144,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -1246,7 +1152,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Stop all broadcasts on every client</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Stop broadcasts</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image20</property>
@@ -1264,6 +1169,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -1271,7 +1177,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Execute a command on the selected clients</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Execute command</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image21</property>
@@ -1287,7 +1192,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Send a message to the selected clients</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Send message</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image22</property>
@@ -1305,6 +1209,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -1312,7 +1217,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Lock screen of the selected clients</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Lock screen</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image23</property>
@@ -1328,7 +1232,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Unlock the screen of the selected clients</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Unlock screen</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image24</property>
@@ -1346,6 +1249,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -1353,7 +1257,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Show information for the selected client</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">Information</property>
                 <property name="use_underline">True</property>
                 <property name="icon_widget">image25</property>
@@ -1372,7 +1275,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHSeparator" id="hseparator1">
+          <object class="GtkSeparator" id="hseparator1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
           </object>
@@ -1383,20 +1286,19 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHPaned" id="hpaned1">
+          <object class="GtkPaned" id="hpaned1">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="position">150</property>
             <child>
-              <object class="GtkVBox" id="vbox2">
+              <object class="GtkBox" id="vbox2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
                     <child>
                       <object class="GtkTreeView" id="groups_tree">
                         <property name="visible">True</property>
@@ -1406,6 +1308,9 @@
                         <property name="search_column">0</property>
                         <signal name="drag-drop" handler="on_gtree_drag_drop" swapped="no"/>
                         <signal name="drag-motion" handler="on_gtree_drag_motion" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                         <child>
                           <object class="GtkTreeViewColumn" id="group_name_column">
                             <property name="title" translatable="yes">Groups</property>
@@ -1430,7 +1335,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
@@ -1438,7 +1343,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="relief">none</property>
                         <signal name="clicked" handler="on_add_group_clicked" swapped="no"/>
                         <child>
@@ -1461,7 +1365,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="relief">none</property>
                         <signal name="clicked" handler="on_remove_group_clicked" swapped="no"/>
                         <child>
@@ -1484,7 +1387,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="relief">none</property>
                         <signal name="clicked" handler="on_move_group_up_clicked" swapped="no"/>
                         <child>
@@ -1506,7 +1408,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="relief">none</property>
                         <signal name="clicked" handler="on_move_group_down_clicked" swapped="no"/>
                         <child>
@@ -1540,17 +1441,16 @@
               <object class="GtkScrolledWindow" id="scrolledwindow3">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
                 <property name="shadow_type">etched-out</property>
                 <child>
                   <object class="GtkIconView" id="clientsview">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="margin">0</property>
                     <property name="selection_mode">multiple</property>
                     <signal name="button-press-event" handler="contextMenuPopup" swapped="no"/>
-                    <signal name="selection-changed" handler="on_clients_selection_changed" swapped="no"/>
                     <signal name="item-activated" handler="monitorUser" swapped="no"/>
+                    <signal name="selection-changed" handler="on_clients_selection_changed" swapped="no"/>
                   </object>
                 </child>
               </object>
@@ -1584,7 +1484,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkHBox" id="hbox4">
+              <object class="GtkBox" id="hbox4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
@@ -1592,7 +1492,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="relief">none</property>
                     <signal name="clicked" handler="scrDecreaseSize" swapped="no"/>
                     <child>
@@ -1610,7 +1509,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHScale" id="hscale1">
+                  <object class="GtkScale" id="hscale1">
                     <property name="width_request">150</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -1633,7 +1532,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="relief">none</property>
                     <signal name="clicked" handler="scrIncreaseSize" swapped="no"/>
                     <child>
@@ -1669,6 +1567,46 @@
       </object>
     </child>
   </object>
+  <object class="GtkMessageDialog" id="executionwarning">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Confirm action</property>
+    <property name="modal">True</property>
+    <property name="type_hint">normal</property>
+    <property name="skip_taskbar_hint">True</property>
+    <property name="transient_for">mainwindow</property>
+    <property name="message_type">warning</property>
+    <property name="buttons">yes-no</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox6">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area6">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkImage" id="image8">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">emblem-people</property>
+  </object>
   <object class="GtkMessageDialog" id="warningDialog">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -1677,13 +1615,17 @@
     <property name="type_hint">normal</property>
     <property name="skip_taskbar_hint">True</property>
     <property name="message_type">warning</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox9">
+      <object class="GtkBox" id="dialog-vbox9">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area9">
+          <object class="GtkButtonBox" id="dialog-action_area9">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -1693,7 +1635,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
               </object>

--- a/epoptes/ui/gtk/executeCommand.ui
+++ b/epoptes/ui/gtk/executeCommand.ui
@@ -4,7 +4,7 @@
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="execDialog">
     <property name="can_focus">False</property>
-    <property name="border_width">10</property>
+    <property name="border_width">12</property>
     <property name="title" translatable="yes">Execute command</property>
     <property name="window_position">center</property>
     <property name="type_hint">normal</property>
@@ -65,6 +65,7 @@
           <object class="GtkLabel" id="label1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
             <property name="label" translatable="yes">URL, file or command to execute on the selected clients:</property>
             <property name="wrap">True</property>
             <property name="xalign">0</property>
@@ -85,7 +86,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="stock">gtk-execute</property>
-                <property name="icon_size">5</property>
+                <property name="icon_size">6</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -97,15 +98,18 @@
               <object class="GtkComboBoxText" id="combobox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <property name="hexpand">True</property>
                 <property name="has_entry">True</property>
                 <child internal-child="entry">
                   <object class="GtkEntry">
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="activates_default">True</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="expand">True</property>
+                <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>

--- a/epoptes/ui/gtk/executeCommand.ui
+++ b/epoptes/ui/gtk/executeCommand.ui
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
-  <object class="GtkEntryCompletion" id="entrycompletion">
-    <property name="minimum_key_length">2</property>
-    <property name="text_column">0</property>
-    <property name="inline_completion">True</property>
-    <property name="popup_completion">False</property>
-    <property name="popup_single_match">False</property>
-    <property name="inline_selection">True</property>
-  </object>
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="execDialog">
     <property name="can_focus">False</property>
     <property name="border_width">10</property>
     <property name="title" translatable="yes">Execute command</property>
     <property name="window_position">center</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
+      <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
+          <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -32,7 +28,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -50,7 +45,6 @@
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -71,9 +65,9 @@
           <object class="GtkLabel" id="label1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes">URL, file or command to execute on the selected clients:</property>
             <property name="wrap">True</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -82,7 +76,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox1">
+          <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">12</property>
@@ -91,7 +85,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="stock">gtk-execute</property>
-                <property name="icon-size">5</property>
+                <property name="icon_size">5</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -100,18 +94,13 @@
               </packing>
             </child>
             <child>
-              <object class="GtkComboBoxEntry" id="combobox">
+              <object class="GtkComboBoxText" id="combobox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="has_entry">True</property>
                 <child internal-child="entry">
-                  <object class="GtkEntry" id="comboboxentry-entry2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_focus">True</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
+                  <object class="GtkEntry">
+                    <property name="can_focus">False</property>
                   </object>
                 </child>
               </object>

--- a/epoptes/ui/gtk/netbenchmark.ui
+++ b/epoptes/ui/gtk/netbenchmark.ui
@@ -1,7 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="2.24"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkMessageDialog" id="msgdlg">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Warning</property>
+    <property name="modal">True</property>
+    <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
+    <property name="message_type">warning</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_message_dialog_close" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="1">button1</action-widget>
+    </action-widgets>
+  </object>
   <object class="GtkListStore" id="results_store">
     <columns>
       <!-- column-name computer -->
@@ -18,12 +71,16 @@
     <property name="title" translatable="yes">Epoptes Network Benchmark Results</property>
     <property name="modal">True</property>
     <child>
-      <object class="GtkVBox" id="vbox2">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox" id="vbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">20</property>
         <child>
-          <object class="GtkHBox" id="hbox6">
+          <object class="GtkBox" id="hbox6">
             <property name="can_focus">False</property>
             <property name="spacing">12</property>
             <child>
@@ -45,16 +102,15 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox3">
+          <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">4</property>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
                 <child>
                   <object class="GtkViewport" id="viewport">
                     <property name="height_request">200</property>
@@ -67,6 +123,9 @@
                         <property name="can_focus">True</property>
                         <property name="model">results_store</property>
                         <property name="search_column">0</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                         <child>
                           <object class="GtkTreeViewColumn" id="computer_column">
                             <property name="title" translatable="yes">Computer</property>
@@ -122,7 +181,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkHBox" id="hbox5">
+              <object class="GtkBox" id="hbox5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
@@ -162,15 +221,14 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="warning_hbox">
+          <object class="GtkBox" id="warning_hbox">
             <property name="can_focus">False</property>
-            <property name="visible">False</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkImage" id="image55">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="stock">gtk-dialog-warning</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="stock">gtk-dialog-warning</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -201,10 +259,12 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox4">
+          <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="spacing">6</property>
+            <property name="halign">center</property>
+            <property name="row_spacing">6</property>
+            <property name="column_spacing">6</property>
             <child>
               <object class="GtkLabel" id="label17">
                 <property name="visible">True</property>
@@ -215,182 +275,136 @@
                 </attributes>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+                <property name="width">4</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkLabel" id="label5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xscale">0</property>
-                <child>
-                  <object class="GtkHBox" id="hbox7">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">24</property>
-                    <child>
-                      <object class="GtkTable" id="table1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="n_rows">2</property>
-                        <property name="n_columns">2</property>
-                        <property name="column_spacing">6</property>
-                        <property name="row_spacing">2</property>
-                        <child>
-                          <object class="GtkLabel" id="label5">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">The average server download bandwidth per client</property>
-                            <property name="xalign">1</property>
-                            <property name="label" translatable="yes">Average server download:</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label6">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">The total server download bandwidth, for all clients, simultaneously</property>
-                            <property name="xalign">1</property>
-                            <property name="label" translatable="yes">Total server download:</property>
-                          </object>
-                          <packing>
-                            <property name="top_attach">1</property>
-                            <property name="bottom_attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="avg_client">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label">— Mbps</property>
-                            <property name="selectable">True</property>
-                            <attributes>
-                              <attribute name="style" value="oblique"/>
-                              <attribute name="weight" value="semibold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="total_client">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label">— Mbps</property>
-                            <property name="selectable">True</property>
-                            <attributes>
-                              <attribute name="style" value="oblique"/>
-                              <attribute name="weight" value="semibold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">1</property>
-                            <property name="bottom_attach">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkTable" id="table2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="n_rows">2</property>
-                        <property name="n_columns">2</property>
-                        <property name="column_spacing">6</property>
-                        <property name="row_spacing">2</property>
-                        <child>
-                          <object class="GtkLabel" id="label9">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">The average server upload bandwidth per client</property>
-                            <property name="xalign">1</property>
-                            <property name="label" translatable="yes">Average server upload:</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label10">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">The total server upload bandwidth, for all clients, simultaneously</property>
-                            <property name="xalign">1</property>
-                            <property name="label" translatable="yes">Total server upload:</property>
-                          </object>
-                          <packing>
-                            <property name="top_attach">1</property>
-                            <property name="bottom_attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="avg_server">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label">— Mbps</property>
-                            <property name="selectable">True</property>
-                            <attributes>
-                              <attribute name="style" value="oblique"/>
-                              <attribute name="weight" value="semibold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="total_server">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label">— Mbps</property>
-                            <property name="selectable">True</property>
-                            <attributes>
-                              <attribute name="style" value="oblique"/>
-                              <attribute name="weight" value="semibold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">1</property>
-                            <property name="bottom_attach">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="pack_type">end</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
+                <property name="tooltip_text" translatable="yes">The average server download bandwidth per client</property>
+                <property name="label" translatable="yes">Average server download:</property>
+                <property name="xalign">1</property>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="avg_client">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">— Mbps</property>
+                <property name="selectable">True</property>
+                <attributes>
+                  <attribute name="style" value="oblique"/>
+                  <attribute name="weight" value="semibold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label9">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">The average server upload bandwidth per client</property>
+                <property name="label" translatable="yes">Average server upload:</property>
+                <property name="xalign">1</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="avg_server">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">— Mbps</property>
+                <property name="selectable">True</property>
+                <attributes>
+                  <attribute name="style" value="oblique"/>
+                  <attribute name="weight" value="semibold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">3</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label6">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">The total server download bandwidth, for all clients, simultaneously</property>
+                <property name="label" translatable="yes">Total server download:</property>
+                <property name="xalign">1</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="total_client">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">— Mbps</property>
+                <property name="selectable">True</property>
+                <attributes>
+                  <attribute name="style" value="oblique"/>
+                  <attribute name="weight" value="semibold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label10">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">The total server upload bandwidth, for all clients, simultaneously</property>
+                <property name="label" translatable="yes">Total server upload:</property>
+                <property name="xalign">1</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="total_server">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">— Mbps</property>
+                <property name="selectable">True</property>
+                <attributes>
+                  <attribute name="style" value="oblique"/>
+                  <attribute name="weight" value="semibold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">3</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="fill">False</property>
             <property name="position">3</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHButtonBox" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -434,12 +448,16 @@
     <property name="modal">True</property>
     <signal name="delete-event" handler="on_window_destroy" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">24</property>
         <child>
-          <object class="GtkHBox" id="hbox1">
+          <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">12</property>
@@ -448,7 +466,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="stock">gtk-properties</property>
-                <property name="icon-size">6</property>
+                <property name="icon_size">6</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -482,7 +500,7 @@ bandwidth that is available for your lab.</property>
             <property name="can_focus">False</property>
             <property name="xscale">0</property>
             <child>
-              <object class="GtkHBox" id="hbox3">
+              <object class="GtkBox" id="hbox3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">6</property>
@@ -506,11 +524,8 @@ bandwidth that is available for your lab.</property>
                     <property name="invisible_char">•</property>
                     <property name="width_chars">3</property>
                     <property name="xalign">1</property>
-                    <property name="invisible_char_set">True</property>
                     <property name="primary_icon_activatable">False</property>
                     <property name="secondary_icon_activatable">False</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
                     <property name="adjustment">seconds_adjustment</property>
                     <property name="climb_rate">1</property>
                     <property name="snap_to_ticks">True</property>
@@ -544,7 +559,7 @@ bandwidth that is available for your lab.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox_status">
+          <object class="GtkBox" id="hbox_status">
             <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <child>
@@ -600,7 +615,7 @@ bandwidth that is available for your lab.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox_buttons">
+          <object class="GtkBox" id="hbox_buttons">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">12</property>
@@ -646,54 +661,5 @@ bandwidth that is available for your lab.</property>
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkMessageDialog" id="msgdlg">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Warning</property>
-    <property name="modal">True</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="message_type">warning</property>
-    <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button1">
-                <property name="label">gtk-close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_message_dialog_close" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="1">button1</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/epoptes/ui/gtk/netbenchmark.ui
+++ b/epoptes/ui/gtk/netbenchmark.ui
@@ -436,26 +436,66 @@
   <object class="GtkAdjustment" id="seconds_adjustment">
     <property name="lower">10</property>
     <property name="upper">340</property>
-    <property name="value">20</property>
+    <property name="value">10</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkWindow" id="benchmark_dialog">
+  <object class="GtkDialog" id="benchmark_dialog">
     <property name="can_focus">False</property>
     <property name="border_width">12</property>
-    <property name="title" translatable="yes">Epoptes Network Benchmark</property>
-    <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <signal name="delete-event" handler="on_window_destroy" swapped="no"/>
+    <property name="type_hint">dialog</property>
     <child>
       <placeholder/>
     </child>
-    <child>
-      <object class="GtkBox" id="vbox1">
-        <property name="visible">True</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">24</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="hbox_buttons">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btn_close">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_btn_close_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_startBenchmark">
+                <property name="label" translatable="yes">Start</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
+                <signal name="clicked" handler="on_btn_startBenchmark_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
@@ -491,76 +531,74 @@ bandwidth that is available for your lab.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
-          <object class="GtkAlignment" id="alignment1">
+          <object class="GtkBox" id="hbox3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xscale">0</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" id="hbox3">
+              <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkLabel" id="label3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Run the benchmark for</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinButton" id="seconds_spinbox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="max_length">3</property>
-                    <property name="invisible_char">•</property>
-                    <property name="width_chars">3</property>
-                    <property name="xalign">1</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="adjustment">seconds_adjustment</property>
-                    <property name="climb_rate">1</property>
-                    <property name="snap_to_ticks">True</property>
-                    <property name="numeric">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">seconds</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
+                <property name="label" translatable="yes">Run the benchmark for</property>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="seconds_spinbox">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="max_length">3</property>
+                <property name="invisible_char">•</property>
+                <property name="width_chars">4</property>
+                <property name="xalign">1</property>
+                <property name="primary_icon_activatable">False</property>
+                <property name="secondary_icon_activatable">False</property>
+                <property name="adjustment">seconds_adjustment</property>
+                <property name="climb_rate">1</property>
+                <property name="snap_to_ticks">True</property>
+                <property name="numeric">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">seconds</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="hbox_status">
             <property name="can_focus">False</property>
+            <property name="halign">center</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkSpinner" id="spinner1">
@@ -610,51 +648,6 @@ bandwidth that is available for your lab.</property>
           </object>
           <packing>
             <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="hbox_buttons">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">12</property>
-            <child>
-              <object class="GtkButton" id="btn_startBenchmark">
-                <property name="label" translatable="yes">Start</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">True</property>
-                <signal name="clicked" handler="on_btn_startBenchmark_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btn_close">
-                <property name="label">gtk-close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_btn_close_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">3</property>
           </packing>

--- a/epoptes/ui/gtk/sendMessage.ui
+++ b/epoptes/ui/gtk/sendMessage.ui
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
-  <object class="GtkImage" id="cancelImage">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="xalign">0</property>
-    <property name="yalign">0</property>
-    <property name="stock">gtk-stop</property>
-  </object>
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkImage" id="sendImage">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -24,13 +17,17 @@
     <property name="default_height">400</property>
     <property name="icon">images/usersgrp.png</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox">
+      <object class="GtkBox" id="dialog-vbox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area">
+          <object class="GtkButtonBox" id="dialog-action_area">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -40,7 +37,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">True</property>
               </object>
@@ -56,7 +52,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="image">sendImage</property>
                 <property name="use_underline">True</property>
               </object>
@@ -75,16 +70,17 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox1">
+          <object class="GtkBox" id="vbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
                 <property name="label" translatable="yes">Message title:</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -99,8 +95,6 @@
                 <property name="invisible_char">●</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -116,16 +110,17 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox2">
+          <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="sendMessageLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
                 <property name="label" translatable="yes">Message text:</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -137,8 +132,6 @@
               <object class="GtkScrolledWindow" id="scrolledwindow">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
                 <child>
                   <object class="GtkTextView" id="Message">
                     <property name="visible">True</property>
@@ -169,7 +162,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="use_action_appearance">False</property>
+            <property name="halign">start</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/epoptes/ui/notifications.py
+++ b/epoptes/ui/notifications.py
@@ -5,6 +5,7 @@
 # Notifications.
 #
 # Copyright (C) 2015 Fotis Tsamis <ftsamis@gmail.com>
+# 2018, Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +14,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -23,10 +24,13 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ###########################################################################
 
-import pynotify
 import os
+import gi
+import sys
+gi.require_version('Notify', '0.7')
+from gi.repository import Notify
 
-if not pynotify.init("epoptes-notifications"):
+if not Notify.init("epoptes-notifications"):
     sys.exit(1)
 
 
@@ -54,13 +58,13 @@ class NotificationCache(object):
 
 
 def notify(title, body, icon):
-    n = pynotify.Notification(title, body, icon)
+    n = Notify.Notification.new(title, body, icon)
     n.set_hint_string("x-canonical-append", "true")
     n.show()
 
 
 def cached_notify(title, body, icon):
-    """A function to replace pynotify.notify if the 'x-canonical-append'
+    """A function to replace Notify.notify if the 'x-canonical-append'
     capability is not provided.
     """
     n = cache.get_notification(title)
@@ -68,23 +72,26 @@ def cached_notify(title, body, icon):
         n.close()
         n.update(title, n.props.body+'\n'+body, icon)
     else:
-        n = pynotify.Notification(title, body, icon)
+        n = Notify.Notification.new(title, body, icon)
         cache.add_notification(n, title)
     n.show()
 
 
-append = 'x-canonical-append' in pynotify.get_server_caps()
+append = 'x-canonical-append' in Notify.get_server_caps()
 if not append:
     cache = NotificationCache()
     notify = cached_notify
 
-def shutdownNotify(host):
+
+def shutdown_notify(host):
     notify(_("Shut down:"), "%s" %(host), os.path.abspath("images/shutdown.svg"))
 
-def loginNotify(user, host):
+
+def login_notify(user, host):
     notify(_("Connected:"), _("%(user)s on %(host)s") %{"user":user, "host":host},
                                 os.path.abspath("images/login.svg"))
-def logoutNotify(user, host):
+
+
+def logout_notify(user, host):
     notify(_("Disconnected:"), _("%(user)s from %(host)s") %{"user":user, "host":host},
                                 os.path.abspath("images/logout.svg"))
-

--- a/epoptes/ui/sendmessage.py
+++ b/epoptes/ui/sendmessage.py
@@ -5,6 +5,7 @@
 # Message sending.
 #
 # Copyright (C) 2010 Fotis Tsamis <ftsamis@gmail.com>
+# 2018, Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +14,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -23,18 +24,15 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ###########################################################################
 
-import gtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 import os
-import pygtk
 
 from epoptes.common import config
 
-pygtk.require('2.0')
 
-wTree = gtk.Builder()
-get = lambda obj: wTree.get_object(obj)
-
-def startSendMessageDlg():
+def startSendMessageDlg(parent):
     """
     Retrieve dialog window from glade format and
     according to type of message requested to send
@@ -42,8 +40,11 @@ def startSendMessageDlg():
     and the message type.
     """
 
+    wTree = Gtk.Builder()
+    get = lambda obj: wTree.get_object(obj)
     wTree.add_from_file('sendMessage.ui')
     dlg = get('sendMessageDialog')
+    dlg.set_transient_for(parent)
     
     textView = get('Message')
     title_entry = get('title_entry')
@@ -58,7 +59,7 @@ def startSendMessageDlg():
         buf = textView.get_buffer()
         s = buf.get_start_iter()
         e = buf.get_end_iter()
-        text = textView.get_buffer().get_text(s,e)
+        text = textView.get_buffer().get_text(s, e, False)
 
         title = title_entry.get_text().strip()
         


### PR DESCRIPTION
This pull request is about migrating the rest of Epoptes to Gtk3, while still on Python2.
Starting now, and until this PR is ready for merging, Epoptes won't be runnable, as it's not possible to import Gtk3 python modules from Gtk2 modules.
Postponing the move to Python3 will hopefully allow us to run Epoptes again in a few weeks.
Also, this PR will only get minimal testing, while full testing will come after the Python3 migration.

## Pull request progress
Files migrated to Gtk3:
- about_dialog.ui client_information.ui epoptes.ui executeCommand.ui netbenchmark.ui sendMessage.ui
- about_dialog.py benchmark.py client_information.py execcommand.py graph.py gui.py notifications.py sendmessage.py

Files still using Gtk2:
- (none left)